### PR TITLE
Add dynamic config

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ The following examples will be parsed using `time.Duration`
 ```
 
 ```shell
-JOB_LENGTH_ENV_VAR="4h"
+TIME_LENGTH_ENV_VAR="4h"
 ```
 
 <a id="markdown-contributing" name="contributing"></a>

--- a/README.md
+++ b/README.md
@@ -282,8 +282,7 @@ SOME_ENV_VAR="a b c"`
 ```
 
 ```yaml
-myvar:
-    theslice: "${SOME_ENV_VAR}"
+theslice: "${SOME_ENV_VAR}"
 ```
 
 ```json

--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ theslice: "${SOME_ENV_VAR}"
 For a given configuration
 ```go
 type Config struct {
-    mapStringSlices *[]string
+    mapStringSlices *map[string][]string
 }
 ```
 The values in the following examples will all be parsed as a string map string slices where the key `letters` and

--- a/README.md
+++ b/README.md
@@ -258,15 +258,104 @@ conjunction with elements from the Hierarchy API, are flexible enough to build
 anything you need.
 
 ## Special Type Parsing and Casting
-The `cast` library we use falls back to JSON for complex types expressed as string values.
-**TODO** Simple examples for the following types to show how they are parsed
-- map[string][]string
-- []string
-- time.Time
-- time.Duration
 
-**NOTE:** Trying to set a `EnvSource` setting of type `map[string][]string` will likely fail,
-but setting an environment variable to this type of value is rare so this shouldn't be a common problem.
+We use the `cast` library for casting values read in from configurations into their go types. The `cast` library 
+falls back to JSON for complex types expressed as string values. Here are some examples of how we parse different types:
+
+**[]string:**
+For a given configuration
+```go
+type Config struct {
+    TheSlice *[]string
+}
+```
+The values in the following examples will all be parsed as a string slice.
+```yaml
+theslice:
+  - "a"
+  - "b"
+  - "c"
+```
+
+```shell
+SOME_ENV_VAR="a b c"`
+```
+
+```yaml
+myvar:
+    theslice: "${SOME_ENV_VAR}"
+```
+
+```json
+{"myvar":  {"theslice":  ["a", "b", "c"]}}
+{"myvar2":  {"theslice":  "${SOME_ENV_VAR}"}}
+```
+
+**map[string][]string:**
+For a given configuration
+```go
+type Config struct {
+    mapStringSlices *[]string
+}
+```
+The values in the following examples will all be parsed as a string map string slices where the key `letters` and
+`symbols` gets included as the string map key.
+```yaml
+myvar:
+    letters:
+      - "a"
+      - "b"
+      - "c"
+    symbols:
+      - "@"
+      - "!"
+```
+
+```json
+{"myvar":  {"letters":  ["a", "b", "c"]}, "symbols":  ["@", "!"]}
+```
+
+**time.Time:**
+For a given configuration
+```go
+type Config struct {
+    TheTime *time.Time
+}
+```
+
+The following examples will be parsed using the RFC3339 format by `time.Parse(time.RFC3339, value)`:
+
+```yaml
+"thetime": "2012-11-01T22:08:41+00:00"
+```
+
+```json
+{"thetime": "2012-11-01T22:08:41+00:00"}
+```
+
+```shell
+TIME_ENV_VAR="2012-11-01T22:08:41+00:00"`
+```
+
+**time.Duration:**
+For a given configuration
+```go
+type Config struct {
+	TimeLength *time.Duration
+}
+```
+The following examples will be parsed using `time.Duration`
+```yaml
+"timeLength": "4h"
+```
+
+```json
+{"timeLength": "4h"}
+```
+
+```shell
+JOB_LENGTH_ENV_VAR="4h"
+```
 
 <a id="markdown-contributing" name="contributing"></a>
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -262,45 +262,66 @@ anything you need.
 We use the `cast` library for casting values read in from configurations into their go types. The `cast` library 
 falls back to JSON for complex types expressed as string values. Here are some examples of how we parse different types:
 
-**[]string:**
+**[]string**
+
 For a given configuration
 ```go
 type Config struct {
-    TheSlice *[]string
+    TheSlice []string
 }
 ```
 The values in the following examples will all be parsed as a string slice.
+
+*yaml*
 ```yaml
-theslice:
-  - "a"
-  - "b"
-  - "c"
+config:
+  theslice:
+    - "a"
+    - "b"
+    - "c"
 ```
 
-```shell
-SOME_ENV_VAR="a b c"`
-```
-
-```yaml
-theslice: "${SOME_ENV_VAR}"
-```
-
+*JSON*
 ```json
-{"theslice":  ["a", "b", "c"]}
-{"theslice":  "${SOME_ENV_VAR}"}
+{"config": {"theslice":  ["a", "b", "c"]}}
 ```
 
-**map[string][]string:**
+You can also set an environment variable and reference them in a YAML or JSON file like below. Note that this
+environment variable value will be parsed as a slice where each letter will be a value since it gets split by any
+space in the string.
+
+*Environment Variable*
+```shell
+CONFIG_THESLICE="a b c"`
+```
+
+*yaml*
+```yaml
+config:
+  theslice: "${CONFIG_THESLICE}"
+```
+
+*JSON*
+```json
+{"config": {"theslice":  "${CONFIG_THESLICE}"}}
+```
+
+**map[string][]string**
+
 For a given configuration
 ```go
 type Config struct {
-    mapStringSlices *map[string][]string
+    allowedStrings map[string][]string
 }
 ```
+
 The values in the following examples will all be parsed as a string map string slices where the key `letters` and
-`symbols` gets included as the string map key.
+`symbols` gets included as the string map key and their values are a string slice.
+
+*yaml*
 ```yaml
-myvar:
+config:
+  allowedStrings:
     letters:
       - "a"
       - "b"
@@ -310,50 +331,69 @@ myvar:
       - "!"
 ```
 
+*JSON*
 ```json
-{"myvar":  {"letters":  ["a", "b", "c"]}, "symbols":  ["@", "!"]}
-```
-
-**time.Time:**
-For a given configuration
-```go
-type Config struct {
-    TheTime *time.Time
+{
+	"config": {
+		"allowedStrings": {
+			"letters": ["a", "b", "c"],
+			"symbols": ["@", "!"]
+		}
+	}
 }
 ```
 
-The following examples will be parsed using the RFC3339 format by `time.Parse(time.RFC3339, value)`:
+**time.Time**
 
+For a given configuration
+```go
+type Config struct {
+    TheTime time.Time
+}
+```
+
+The following examples will be parsed using the RFC3339 format by `time.Parse(time.RFC3339, value)`
+
+*yaml*
 ```yaml
-"thetime": "2012-11-01T22:08:41+00:00"
+"config":
+  "thetime": "2012-11-01T22:08:41+00:00"
 ```
 
+*JSON*
 ```json
-{"thetime": "2012-11-01T22:08:41+00:00"}
+{"config": {"thetime": "2012-11-01T22:08:41+00:00"}}
 ```
 
+*Environment Variable*
 ```shell
-TIME_ENV_VAR="2012-11-01T22:08:41+00:00"`
+CONFIG_THETIME="2012-11-01T22:08:41+00:00"`
 ```
 
-**time.Duration:**
+**time.Duration**
+
 For a given configuration
 ```go
 type Config struct {
-	TimeLength *time.Duration
+	TimeLength time.Duration
 }
 ```
+
 The following examples will be parsed using `time.Duration`
+*yaml*
 ```yaml
-"timeLength": "4h"
+"config":
+  "timeLength": "4h"
 ```
 
+*JSON*
 ```json
-{"timeLength": "4h"}
+{"config": {"timeLength": "4h"}}
 ```
 
+*Environment Variable*
 ```shell
-TIME_LENGTH_ENV_VAR="4h"
+CONFIG_TIMELENGTH="4h"
 ```
 
 <a id="markdown-contributing" name="contributing"></a>

--- a/README.md
+++ b/README.md
@@ -287,8 +287,8 @@ myvar:
 ```
 
 ```json
-{"myvar":  {"theslice":  ["a", "b", "c"]}}
-{"myvar2":  {"theslice":  "${SOME_ENV_VAR}"}}
+{"theslice":  ["a", "b", "c"]}
+{"theslice":  "${SOME_ENV_VAR}"}
 ```
 
 **map[string][]string:**

--- a/README.md
+++ b/README.md
@@ -257,6 +257,17 @@ replacing the type converters with something else. These elements, in possible
 conjunction with elements from the Hierarchy API, are flexible enough to build
 anything you need.
 
+## Special Type Parsing and Casting
+The `cast` library we use falls back to JSON for complex types expressed as string values.
+**TODO** Simple examples for the following types to show how they are parsed
+- map[string][]string
+- []string
+- time.Time
+- time.Duration
+
+**NOTE:** Trying to set a `EnvSource` setting of type `map[string][]string` will likely fail,
+but setting an environment variable to this type of value is rare so this shouldn't be a common problem.
+
 <a id="markdown-contributing" name="contributing"></a>
 ## Contributing
 

--- a/convert.go
+++ b/convert.go
@@ -192,6 +192,20 @@ func settingFromValue(name string, description string, v reflect.Value) (Setting
 		sv := reflect.Indirect(reflect.ValueOf(s))
 		sv.FieldByName("Int64Value").Set(v.Addr())
 		return s, nil
+	case reflect.Map:
+		vTypeStored := v.Type()
+		if vTypeStored.String() == "map[string][]string"{
+			s := &StringMapStringSliceSetting{
+				BaseSetting: &BaseSetting{
+					NameValue: name,
+					DescriptionValue: description,
+				},
+			}
+			sv := reflect.Indirect(reflect.ValueOf(s))
+			sv.FieldByName("StringMapStringSliceValue").Set(v.Addr())
+			return s, nil
+		}
+		return nil, fmt.Errorf("unknown map value type for setting %s", vTypeStored)
 	case reflect.Uint:
 		s := &UintSetting{
 			BaseSetting: &BaseSetting{

--- a/convert.go
+++ b/convert.go
@@ -42,7 +42,7 @@ func Convert(v interface{}) (Group, error) {
 	// Every struct may, optionally, provide the namer interface in order
 	// to control the name of the group. If a struct does not expose the
 	// name interface then we use the name of the struct with the package
-	// name removed as an identfier. The same is true for description except
+	// name removed as an identifier. The same is true for description except
 	// that we do not add a default description.
 	nameTmp := strings.Split(vv.Type().Name(), ".")
 	name := nameTmp[len(nameTmp)-1]
@@ -65,7 +65,7 @@ func Convert(v interface{}) (Group, error) {
 	for x := 0; x < vv.NumField(); x = x + 1 {
 		// The Value and Type versions of Field() return different types that
 		// contain different information. The Type.Field() generates a TypeField
-		// that contains the details needed to determin the field name and whether
+		// that contains the details needed to determine the field name and whether
 		// it is embedded or not. The Value.Field() returns a Value that can be used
 		// to manipulate the field.
 		stack = append(stack, fieldAndValue{Value: vv.Field(x), Field: vv.Type().Field(x)})

--- a/convert.go
+++ b/convert.go
@@ -194,7 +194,8 @@ func settingFromValue(name string, description string, v reflect.Value) (Setting
 		return s, nil
 	case reflect.Map:
 		vTypeStored := v.Type()
-		if vTypeStored.String() == "map[string][]string" {
+		switch vTypeStored.String(){
+		case "map[string][]string":
 			s := &StringMapStringSliceSetting{
 				BaseSetting: &BaseSetting{
 					NameValue:        name,
@@ -204,8 +205,9 @@ func settingFromValue(name string, description string, v reflect.Value) (Setting
 			sv := reflect.Indirect(reflect.ValueOf(s))
 			sv.FieldByName("StringMapStringSliceValue").Set(v.Addr())
 			return s, nil
+		default:
+			return nil, fmt.Errorf("unknown map value type for setting %s", vTypeStored)
 		}
-		return nil, fmt.Errorf("unknown map value type for setting %s", vTypeStored)
 	case reflect.Uint:
 		s := &UintSetting{
 			BaseSetting: &BaseSetting{

--- a/convert.go
+++ b/convert.go
@@ -194,10 +194,10 @@ func settingFromValue(name string, description string, v reflect.Value) (Setting
 		return s, nil
 	case reflect.Map:
 		vTypeStored := v.Type()
-		if vTypeStored.String() == "map[string][]string"{
+		if vTypeStored.String() == "map[string][]string" {
 			s := &StringMapStringSliceSetting{
 				BaseSetting: &BaseSetting{
-					NameValue: name,
+					NameValue:        name,
 					DescriptionValue: description,
 				},
 			}

--- a/convert.go
+++ b/convert.go
@@ -194,7 +194,7 @@ func settingFromValue(name string, description string, v reflect.Value) (Setting
 		return s, nil
 	case reflect.Map:
 		vTypeStored := v.Type()
-		switch vTypeStored.String(){
+		switch vTypeStored.String() {
 		case "map[string][]string":
 			s := &StringMapStringSliceSetting{
 				BaseSetting: &BaseSetting{

--- a/convert_test.go
+++ b/convert_test.go
@@ -252,7 +252,18 @@ func TestConvert(t *testing.T) {
 			},
 			wantErr: false,
 		},
-
+		{
+			name: "struct/map[string][]string",
+			v: &(struct{ V map[string][]string }{
+				V: map[string][]string{"letters": {"a", "b"}, "characters": {"!", "@"}}}),
+			want: &SettingGroup{
+				SettingValues: []Setting{
+					NewStringMapStringSliceSetting("V", "",
+						map[string][]string{"letters": {"a", "b"}, "characters": {"!", "@"}}),
+				},
+			},
+			wantErr: false,
+		},
 		{
 			name: "struct/named",
 			v:    &named{},

--- a/setting.go
+++ b/setting.go
@@ -666,3 +666,28 @@ func (s *StringSliceSetting) SetValue(v interface{}) error {
 	*s.StringSliceValue, err = cast.ToStringSliceE(v)
 	return err
 }
+
+type StringMapStringSliceSetting struct {
+	*BaseSetting
+	StringMapStringSliceValue *map[string][]string
+}
+
+
+func (m *StringMapStringSliceSetting) Value() interface{} {
+	return *m.StringMapStringSliceValue
+}
+
+func (m *StringMapStringSliceSetting) SetValue(v interface{}) error {
+	var err error
+	*m.StringMapStringSliceValue, err = cast.ToStringMapStringSliceE(v)
+	return err
+}
+func NewStringMapStringSliceSetting(name string, description string, fallback map[string][]string) *StringMapStringSliceSetting {
+	return &StringMapStringSliceSetting{
+		BaseSetting: &BaseSetting{
+			NameValue: name,
+			DescriptionValue: description,
+		},
+		StringMapStringSliceValue: &fallback,
+	}
+}

--- a/setting.go
+++ b/setting.go
@@ -667,20 +667,25 @@ func (s *StringSliceSetting) SetValue(v interface{}) error {
 	return err
 }
 
+// StringMapStringSliceSetting manages an instance of map[string][]string.
 type StringMapStringSliceSetting struct {
 	*BaseSetting
 	StringMapStringSliceValue *map[string][]string
 }
 
+// Value returns the underlying map[string][]string.
 func (m *StringMapStringSliceSetting) Value() interface{} {
 	return *m.StringMapStringSliceValue
 }
 
+// SetValue changes the underlying map[string][]string.
 func (m *StringMapStringSliceSetting) SetValue(v interface{}) error {
 	var err error
 	*m.StringMapStringSliceValue, err = cast.ToStringMapStringSliceE(v)
 	return err
 }
+
+// NewStringMapStringSliceSetting creates a StringMapStringSliceSetting with the given default value.
 func NewStringMapStringSliceSetting(name string, description string, fallback map[string][]string) *StringMapStringSliceSetting {
 	return &StringMapStringSliceSetting{
 		BaseSetting: &BaseSetting{

--- a/setting.go
+++ b/setting.go
@@ -672,7 +672,6 @@ type StringMapStringSliceSetting struct {
 	StringMapStringSliceValue *map[string][]string
 }
 
-
 func (m *StringMapStringSliceSetting) Value() interface{} {
 	return *m.StringMapStringSliceValue
 }
@@ -685,7 +684,7 @@ func (m *StringMapStringSliceSetting) SetValue(v interface{}) error {
 func NewStringMapStringSliceSetting(name string, description string, fallback map[string][]string) *StringMapStringSliceSetting {
 	return &StringMapStringSliceSetting{
 		BaseSetting: &BaseSetting{
-			NameValue: name,
+			NameValue:        name,
 			DescriptionValue: description,
 		},
 		StringMapStringSliceValue: &fallback,

--- a/setting.go
+++ b/setting.go
@@ -678,6 +678,7 @@ func (m *StringMapStringSliceSetting) Value() interface{} {
 
 func (m *StringMapStringSliceSetting) SetValue(v interface{}) error {
 	var err error
+	fmt.Println("####INCOMING VALUE######## : ", v)
 	*m.StringMapStringSliceValue, err = cast.ToStringMapStringSliceE(v)
 	return err
 }

--- a/setting.go
+++ b/setting.go
@@ -678,7 +678,6 @@ func (m *StringMapStringSliceSetting) Value() interface{} {
 
 func (m *StringMapStringSliceSetting) SetValue(v interface{}) error {
 	var err error
-	fmt.Println("####INCOMING VALUE######## : ", v)
 	*m.StringMapStringSliceValue, err = cast.ToStringMapStringSliceE(v)
 	return err
 }

--- a/setting_test.go
+++ b/setting_test.go
@@ -157,9 +157,9 @@ func TestSetting(t *testing.T) {
 		{
 			name: "StringMapStringSlice",
 			setting: NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
-			good: map[string][]string{"a":{"a", "c"}},
-			expected: map[string][]string{"a":{"a", "c"}},
-			bad: "false",
+			good: `{"animals": ["cats", "dogs", "fish"]}`,
+			expected: map[string][]string{"animals":{"cats", "dogs", "fish"}},
+			bad: `{"animal": "dog"}`,
 		},
 	}
 	for _, tt := range tests {

--- a/setting_test.go
+++ b/setting_test.go
@@ -8,10 +8,13 @@ import (
 
 func getParsedYamlTestFixture(t *testing.T) map[string]interface{} {
 	yamlTestString := `
-animals:
-  - cats
-  - dogs
-  - fish
+fruits:
+  - apple
+  - orange
+  - mango
+vegetables:
+  - corn
+  - squash
 `
 	testS, err := NewYAMLSource([]byte(yamlTestString))
 	if err != nil {
@@ -171,15 +174,15 @@ func TestSetting(t *testing.T) {
 		{
 			name:     "StringMapStringSlice from JSON",
 			setting:  NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
-			good:     `{"animals": ["cats", "dogs", "fish"]}`,
-			expected: map[string][]string{"animals": {"cats", "dogs", "fish"}},
+			good:     `{"dogs": ["german shepard", "golden retriever"], "birds": ["eagle", "pigeon"]}`,
+			expected: map[string][]string{"dogs": {"german shepard", "golden retriever"}, "birds": {"eagle", "pigeon"}},
 			bad:      `{"animal": "dog"}`,
 		},
 		{
 			name:     "StringMapStringSlice from YAML",
 			setting:  NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
 			good:     getParsedYamlTestFixture(t),
-			expected: map[string][]string{"animals": {"cats", "dogs", "fish"}},
+			expected: map[string][]string{"fruits": {"apple", "orange", "mango"}, "vegetables": {"corn", "squash"}},
 			bad:      `- animal - dog`,
 		},
 	}

--- a/setting_test.go
+++ b/setting_test.go
@@ -1,13 +1,12 @@
 package settings
 
 import (
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
 )
 
-func getParsedYamlTestFixture() map[string]interface{}{
+func getParsedYamlTestFixture(t *testing.T) map[string]interface{} {
 	yamlTestString := `
 animals:
   - cats
@@ -16,7 +15,7 @@ animals:
 `
 	testS, err := NewYAMLSource([]byte(yamlTestString))
 	if err != nil {
-		fmt.Println(err)
+		t.Errorf("failed to parse YAML test fixture due to %s", err)
 	}
 	return testS.Map
 }
@@ -170,18 +169,18 @@ func TestSetting(t *testing.T) {
 			bad:      make(map[string]interface{}),
 		},
 		{
-			name: "StringMapStringSlice from JSON",
-			setting: NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
-			good: `{"animals": ["cats", "dogs", "fish"]}`,
-			expected: map[string][]string{"animals":{"cats", "dogs", "fish"}},
-			bad: `{"animal": "dog"}`,
+			name:     "StringMapStringSlice from JSON",
+			setting:  NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
+			good:     `{"animals": ["cats", "dogs", "fish"]}`,
+			expected: map[string][]string{"animals": {"cats", "dogs", "fish"}},
+			bad:      `{"animal": "dog"}`,
 		},
 		{
-			name: "StringMapStringSlice from YAML",
-			setting: NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
-			good: getParsedYamlTestFixture(),
-			expected: map[string][]string{"animals":{"cats", "dogs", "fish"}},
-			bad: `- animal - dog`,
+			name:     "StringMapStringSlice from YAML",
+			setting:  NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
+			good:     getParsedYamlTestFixture(t),
+			expected: map[string][]string{"animals": {"cats", "dogs", "fish"}},
+			bad:      `- animal - dog`,
 		},
 	}
 	for _, tt := range tests {

--- a/setting_test.go
+++ b/setting_test.go
@@ -1,10 +1,25 @@
 package settings
 
 import (
+	"fmt"
 	"reflect"
 	"testing"
 	"time"
 )
+
+func getParsedYamlTestFixture() map[string]interface{}{
+	yamlTestString := `
+animals:
+  - cats
+  - dogs
+  - fish
+`
+	testS, err := NewYAMLSource([]byte(yamlTestString))
+	if err != nil {
+		fmt.Println(err)
+	}
+	return testS.Map
+}
 
 func TestSetting(t *testing.T) {
 	tests := []struct {
@@ -155,11 +170,18 @@ func TestSetting(t *testing.T) {
 			bad:      make(map[string]interface{}),
 		},
 		{
-			name: "StringMapStringSlice",
+			name: "StringMapStringSlice from JSON",
 			setting: NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
 			good: `{"animals": ["cats", "dogs", "fish"]}`,
 			expected: map[string][]string{"animals":{"cats", "dogs", "fish"}},
 			bad: `{"animal": "dog"}`,
+		},
+		{
+			name: "StringMapStringSlice from YAML",
+			setting: NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
+			good: getParsedYamlTestFixture(),
+			expected: map[string][]string{"animals":{"cats", "dogs", "fish"}},
+			bad: `- animal - dog`,
 		},
 	}
 	for _, tt := range tests {

--- a/setting_test.go
+++ b/setting_test.go
@@ -154,6 +154,13 @@ func TestSetting(t *testing.T) {
 			expected: []string{"one", "two", "three"},
 			bad:      make(map[string]interface{}),
 		},
+		{
+			name: "StringMapStringSlice",
+			setting: NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
+			good: map[string][]string{"a":{"a", "c"}},
+			expected: map[string][]string{"a":{"a", "c"}},
+			bad: "false",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Goal of this pull request is to add the ability for consumers of `settings` to be able to declare key, value pairs of configurations where the values are an array and have `settings` load them as a `map[string][]string`

**TODO**
- [x] Get feedback
- [x] Address feedback
- [x] Add unit tests to `convert_test.go`
- [x] Add documentation