### PR TITLE
add support for map[string]string type parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-<a id="markdown-settings---typed-configuration-toolkit-for-go" name="settings---typed-configuration-toolkit-for-go"></a>
 # Settings - Typed Configuration Toolkit For Go
 [![GoDoc](https://godoc.org/github.com/asecurityteam/settings?status.svg)](https://godoc.org/github.com/asecurityteam/settings)
 [![Build Status](https://travis-ci.com/asecurityteam/settings.png?branch=master)](https://travis-ci.com/asecurityteam/settings)
@@ -6,21 +5,8 @@
 
 *Status: Incubation*
 
-<!-- TOC -->
+<!-- TOC -->autoauto- [Settings - Typed Configuration Toolkit For Go](#settings---typed-configuration-toolkit-for-go)auto    - [Overview](#overview)auto    - [Data Sources](#data-sources)auto    - [Component API](#component-api)auto    - [Hierarchy API](#hierarchy-api)auto    - [Adapter API](#adapter-api)auto    - [Special Type Parsing and Casting](#special-type-parsing-and-casting)auto    - [Contributing](#contributing)auto        - [License](#license)auto        - [Contributing Agreement](#contributing-agreement)autoauto<!-- /TOC -->
 
-- [Settings - Typed Configuration Toolkit For Go](#settings---typed-configuration-toolkit-for-go)
-    - [Overview](#overview)
-    - [Data Sources](#data-sources)
-    - [Component API](#component-api)
-    - [Hierarchy API](#hierarchy-api)
-    - [Adapter API](#adapter-api)
-    - [Contributing](#contributing)
-        - [License](#license)
-        - [Contributing Agreement](#contributing-agreement)
-
-<!-- /TOC -->
-
-<a id="markdown-overview" name="overview"></a>
 ## Overview
 
 There aren't very many well tested and maintained libraries in the ecosystem for
@@ -63,7 +49,6 @@ attempts to overcome those small deficits by offering:
 -   A low level API for interfacing between statically typed options and weakly typed
     configuration sources.
 
-<a id="markdown-data-sources" name="data-sources"></a>
 ## Data Sources
 
 All forms of our API interact in some with a source of configuration data. The
@@ -107,7 +92,6 @@ source is responsible for safely converting the result into a useful value.
 
 We recommend using one of the API layers we provide to do this for you.
 
-<a id="markdown-component-api" name="component-api"></a>
 ## Component API
 
 With one of our goals being the support of plugin based systems, we've built
@@ -217,7 +201,6 @@ toptree:
 
 The descriptions are used to annotate example configurations and help output.
 
-<a id="markdown-hierarchy-api" name="hierarchy-api"></a>
 ## Hierarchy API
 
 If the component API is too restrictive for your use case then the Hierarchy API
@@ -244,7 +227,6 @@ After loading is complete, each `Setting` value will contain either the given de
 for a the value found in the `Source`. This is the same API we used to create the
 Component API.
 
-<a id="markdown-adapter-api" name="adapter-api"></a>
 ## Adapter API
 
 If none of the higher API layers provide what you need then we also offer a lower
@@ -346,6 +328,38 @@ config:
 }
 ```
 
+**map[string]string**
+
+For a given configuration
+```go
+type Config struct {
+    headers map[string]string
+}
+```
+
+The values in the following examples will all be parsed as a string map of string values where the key and
+values get included as the string map key to string values.
+
+*yaml*
+```yaml
+config:
+  headers:
+    x-header-1: "a"
+    x-header-2: "b"
+```
+
+*JSON*
+```json
+{
+	"config": {
+		"headers": {
+			"x-header-1": "a",
+			"x-header-2": "b"
+		}
+	}
+}
+```
+
 **time.Time**
 
 For a given configuration
@@ -399,15 +413,12 @@ The following examples will be parsed using `time.Duration`
 CONFIG_TIMELENGTH="4h"
 ```
 
-<a id="markdown-contributing" name="contributing"></a>
 ## Contributing
 
-<a id="markdown-license" name="license"></a>
 ### License
 
 This project is licensed under Apache 2.0. See LICENSE.txt for details.
 
-<a id="markdown-contributing-agreement" name="contributing-agreement"></a>
 ### Contributing Agreement
 
 Atlassian requires signing a contributor's agreement before we can accept a patch. If

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+<a id="markdown-settings---typed-configuration-toolkit-for-go" name="settings---typed-configuration-toolkit-for-go"></a>
 # Settings - Typed Configuration Toolkit For Go
 [![GoDoc](https://godoc.org/github.com/asecurityteam/settings?status.svg)](https://godoc.org/github.com/asecurityteam/settings)
 [![Build Status](https://travis-ci.com/asecurityteam/settings.png?branch=master)](https://travis-ci.com/asecurityteam/settings)
@@ -5,8 +6,21 @@
 
 *Status: Incubation*
 
-<!-- TOC -->autoauto- [Settings - Typed Configuration Toolkit For Go](#settings---typed-configuration-toolkit-for-go)auto    - [Overview](#overview)auto    - [Data Sources](#data-sources)auto    - [Component API](#component-api)auto    - [Hierarchy API](#hierarchy-api)auto    - [Adapter API](#adapter-api)auto    - [Special Type Parsing and Casting](#special-type-parsing-and-casting)auto    - [Contributing](#contributing)auto        - [License](#license)auto        - [Contributing Agreement](#contributing-agreement)autoauto<!-- /TOC -->
+<!-- TOC -->
 
+- [Settings - Typed Configuration Toolkit For Go](#settings---typed-configuration-toolkit-for-go)
+    - [Overview](#overview)
+    - [Data Sources](#data-sources)
+    - [Component API](#component-api)
+    - [Hierarchy API](#hierarchy-api)
+    - [Adapter API](#adapter-api)
+    - [Contributing](#contributing)
+        - [License](#license)
+        - [Contributing Agreement](#contributing-agreement)
+
+<!-- /TOC -->
+
+<a id="markdown-overview" name="overview"></a>
 ## Overview
 
 There aren't very many well tested and maintained libraries in the ecosystem for
@@ -49,6 +63,7 @@ attempts to overcome those small deficits by offering:
 -   A low level API for interfacing between statically typed options and weakly typed
     configuration sources.
 
+<a id="markdown-data-sources" name="data-sources"></a>
 ## Data Sources
 
 All forms of our API interact in some with a source of configuration data. The
@@ -92,6 +107,7 @@ source is responsible for safely converting the result into a useful value.
 
 We recommend using one of the API layers we provide to do this for you.
 
+<a id="markdown-component-api" name="component-api"></a>
 ## Component API
 
 With one of our goals being the support of plugin based systems, we've built
@@ -201,6 +217,7 @@ toptree:
 
 The descriptions are used to annotate example configurations and help output.
 
+<a id="markdown-hierarchy-api" name="hierarchy-api"></a>
 ## Hierarchy API
 
 If the component API is too restrictive for your use case then the Hierarchy API
@@ -227,6 +244,7 @@ After loading is complete, each `Setting` value will contain either the given de
 for a the value found in the `Source`. This is the same API we used to create the
 Component API.
 
+<a id="markdown-adapter-api" name="adapter-api"></a>
 ## Adapter API
 
 If none of the higher API layers provide what you need then we also offer a lower
@@ -244,7 +262,7 @@ anything you need.
 
 ## Special Type Parsing and Casting
 
-We use the `cast` library for casting values read in from configurations into their go types. The `cast` library 
+We use the `cast` library for casting values read in from configurations into their go types. The `cast` library
 falls back to JSON for complex types expressed as string values. Here are some examples of how we parse different types:
 
 **[]string**
@@ -333,7 +351,7 @@ config:
 For a given configuration
 ```go
 type Config struct {
-    headers map[string]string
+    foods map[string]string
 }
 ```
 
@@ -343,18 +361,18 @@ values get included as the string map key to string values.
 *yaml*
 ```yaml
 config:
-  headers:
-    x-header-1: "a"
-    x-header-2: "b"
+  foods:
+    apple: "fruit"
+    broccoli: "vegetable"
 ```
 
 *JSON*
 ```json
 {
 	"config": {
-		"headers": {
-			"x-header-1": "a",
-			"x-header-2": "b"
+		"foods": {
+			"apple": "fruit",
+			"broccoli": "vegetable"
 		}
 	}
 }
@@ -413,12 +431,15 @@ The following examples will be parsed using `time.Duration`
 CONFIG_TIMELENGTH="4h"
 ```
 
+<a id="markdown-contributing" name="contributing"></a>
 ## Contributing
 
+<a id="markdown-license" name="license"></a>
 ### License
 
 This project is licensed under Apache 2.0. See LICENSE.txt for details.
 
+<a id="markdown-contributing-agreement" name="contributing-agreement"></a>
 ### Contributing Agreement
 
 Atlassian requires signing a contributor's agreement before we can accept a patch. If

--- a/convert.go
+++ b/convert.go
@@ -205,6 +205,16 @@ func settingFromValue(name string, description string, v reflect.Value) (Setting
 			sv := reflect.Indirect(reflect.ValueOf(s))
 			sv.FieldByName("StringMapStringSliceValue").Set(v.Addr())
 			return s, nil
+		case "map[string]string":
+			s := &StringMapStringSetting{
+				BaseSetting: &BaseSetting{
+					NameValue:        name,
+					DescriptionValue: description,
+				},
+			}
+			sv := reflect.Indirect(reflect.ValueOf(s))
+			sv.FieldByName("StringMapStringValue").Set(v.Addr())
+			return s, nil
 		default:
 			return nil, fmt.Errorf("unknown map value type for setting %s", vTypeStored)
 		}

--- a/convert_test.go
+++ b/convert_test.go
@@ -265,6 +265,18 @@ func TestConvert(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "struct/map[string]string",
+			v: &(struct{ V map[string]string }{
+				V: map[string]string{"letter": "a", "character": "!"}}),
+			want: &SettingGroup{
+				SettingValues: []Setting{
+					NewStringMapStringSetting("V", "",
+						map[string]string{"letter": "a", "character": "!"}),
+				},
+			},
+			wantErr: false,
+		},
+		{
 			name: "struct/named",
 			v:    &named{},
 			want: &SettingGroup{

--- a/setting.go
+++ b/setting.go
@@ -695,3 +695,32 @@ func NewStringMapStringSliceSetting(name string, description string, fallback ma
 		StringMapStringSliceValue: &fallback,
 	}
 }
+
+// StringMapStringSetting manages an instance of map[string]string.
+type StringMapStringSetting struct {
+	*BaseSetting
+	StringMapStringValue *map[string]string
+}
+
+// Value returns the underlying map[string][]string.
+func (m *StringMapStringSetting) Value() interface{} {
+	return *m.StringMapStringValue
+}
+
+// SetValue changes the underlying map[string][]string.
+func (m *StringMapStringSetting) SetValue(v interface{}) error {
+	var err error
+	*m.StringMapStringValue, err = cast.ToStringMapStringE(v)
+	return err
+}
+
+// NewStringMapStringSetting creates a StringMapStringSetting with the given default value.
+func NewStringMapStringSetting(name string, description string, fallback map[string]string) *StringMapStringSetting {
+	return &StringMapStringSetting{
+		BaseSetting: &BaseSetting{
+			NameValue:        name,
+			DescriptionValue: description,
+		},
+		StringMapStringValue: &fallback,
+	}
+}

--- a/setting_test.go
+++ b/setting_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 )
 
-func getParsedYamlTestFixture(t *testing.T) map[string]interface{} {
+func getParsedYamlTestFixtureForMapStringToSlice(t *testing.T) map[string]interface{} {
 	yamlTestString := `
 fruits:
   - apple
@@ -15,6 +15,18 @@ fruits:
 vegetables:
   - corn
   - squash
+`
+	testS, err := NewYAMLSource([]byte(yamlTestString))
+	if err != nil {
+		t.Errorf("failed to parse YAML test fixture due to %s", err)
+	}
+	return testS.Map
+}
+
+func getParsedYamlTestFixtureForMapStringToString(t *testing.T) map[string]interface{} {
+	yamlTestString := `
+fruit: apple
+vegetable: corn
 `
 	testS, err := NewYAMLSource([]byte(yamlTestString))
 	if err != nil {
@@ -181,8 +193,22 @@ func TestSetting(t *testing.T) {
 		{
 			name:     "StringMapStringSlice from YAML",
 			setting:  NewStringMapStringSliceSetting("StringMapStringSlice", "", nil),
-			good:     getParsedYamlTestFixture(t),
+			good:     getParsedYamlTestFixtureForMapStringToSlice(t),
 			expected: map[string][]string{"fruits": {"apple", "orange", "mango"}, "vegetables": {"corn", "squash"}},
+			bad:      `- animal - dog`,
+		},
+		{
+			name:     "StringMapString from JSON",
+			setting:  NewStringMapStringSetting("StringMapString", "", nil),
+			good:     `{"dog": "german shepard", "bird": "eagle"}`,
+			expected: map[string]string{"dog": "german shepard", "bird": "eagle"},
+			bad:      `{"animal": ["dog"]}`,
+		},
+		{
+			name:     "StringMapString from YAML",
+			setting:  NewStringMapStringSetting("StringMapString", "", nil),
+			good:     getParsedYamlTestFixtureForMapStringToString(t),
+			expected: map[string]string{"fruit": "apple", "vegetable": "corn"},
 			bad:      `- animal - dog`,
 		},
 	}


### PR DESCRIPTION
Desire is to support parsing into `map[string]string` for such YAML constructs like:

```
headers:
    x-header-1: "a",
    x-header-2: "b"
```
