### PR TITLE
fix broken file closure deferral

### DIFF
--- a/source.go
+++ b/source.go
@@ -137,7 +137,12 @@ func NewFileSource(path string) (*MapSource, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer f.Close()
+	// changed how we handled a deferred file closure due to go lint security check https://github.com/securego/gosec/issues/512#issuecomment-675286833
+	defer func() {
+		if cerr := f.Close(); cerr != nil {
+			fmt.Printf("Error closing file: %s\n", cerr)
+		}
+	}()
 	b, err := ioutil.ReadAll(f)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Due to new go linting rule https://github.com/securego/gosec/issues/512 our code that handles file closures is now considered unsafe so I went with a minimal fix.

I don't think this should be harmful as it just explicitly prints the error output here. Previously when we used "defer" the error just goes unhandled, so this is already an improvement. 