### PR TITLE
implement var substitution feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,7 @@ finalSource := []settings.MultiSource{prefixedEnv, yamlSource, jsonSource}
 v, found := finalSource.Get(context.Background(), "setting")
 ```
 
-`MultiSource` supports variable substitution, so that you can effectively perform
-variable mapping.  For example, in the following, the final value of `B_BB` key will
+The built-in sources, including `MultiSource`, support variable substitution, so that you can effectively perform variable mapping.  For example, in the following, the final value of `B_BB` key will
 be `envValue`.
 
 *config.yaml* (be sure to wrap reference values in quotes so the yaml parser interprets it as a string)
@@ -117,6 +116,24 @@ A_AA="envValue"
 yamlSource, _ := settings.NewFileSource("config.yaml")
 envSource := settings.NewEnvSource(os.Environ())
 finalSource := []settings.MultiSource{yamlSource, envSource}
+```
+
+Recursion protection is such that recursing to a depth of ten will result in the value
+at the "top" of the recursion stack being returned.  For example, the following will
+return a literal unexpanded value `${b}` when getting key `a` due to infinite recursion
+protection.
+
+```yaml
+a: "${b}"
+b: "${c}"
+c: "${a}"
+```
+
+Similarly, the literal value is returned when no expansion is possible.  The following will
+return a literal unexpanded value `${b}` when getting key `a`:
+
+```yaml
+a: "${b}"
 ```
 
 Sources may be used as-is by passing them around to components that need to fetch

--- a/README.md
+++ b/README.md
@@ -9,14 +9,15 @@
 <!-- TOC -->
 
 - [Settings - Typed Configuration Toolkit For Go](#settings---typed-configuration-toolkit-for-go)
-    - [Overview](#overview)
-    - [Data Sources](#data-sources)
-    - [Component API](#component-api)
-    - [Hierarchy API](#hierarchy-api)
-    - [Adapter API](#adapter-api)
-    - [Contributing](#contributing)
-        - [License](#license)
-        - [Contributing Agreement](#contributing-agreement)
+  - [Overview](#overview)
+  - [Data Sources](#data-sources)
+  - [Component API](#component-api)
+  - [Hierarchy API](#hierarchy-api)
+  - [Adapter API](#adapter-api)
+  - [Special Type Parsing and Casting](#special-type-parsing-and-casting)
+  - [Contributing](#contributing)
+    - [License](#license)
+    - [Contributing Agreement](#contributing-agreement)
 
 <!-- /TOC -->
 
@@ -91,10 +92,31 @@ prefixedEnv := &settings.PrefixSource{
     Prefix: []string{"APP"},
 }
 // Create an ordered lookup where ENV is first with a fallback to
-// YAML which can fallback to JSON.
+// YAML which can fallback to JSON.  The first found is used.
 finalSource := []settings.MultiSource{prefixedEnv, yamlSource, jsonSource}
 
 v, found := finalSource.Get(context.Background(), "setting")
+```
+
+`MultiSource` supports variable substitution, so that you can effectively perform
+variable mapping.  For example, in the following, the final value of `B_BB` key will
+be `envValue`.
+
+*config.yaml* (be sure to wrap reference values in quotes so the yaml parser interprets it as a string)
+```yaml
+b:
+  bb: "${A_AA}"
+```
+
+*Environment Variable*
+```shell
+A_AA="envValue"
+```
+
+```golang
+yamlSource, _ := settings.NewFileSource("config.yaml")
+envSource := settings.NewEnvSource(os.Environ())
+finalSource := []settings.MultiSource{yamlSource, envSource}
 ```
 
 Sources may be used as-is by passing them around to components that need to fetch

--- a/source.go
+++ b/source.go
@@ -77,13 +77,12 @@ func NewMapSource(m map[string]interface{}) *MapSource {
 }
 
 // Get traverses a configuration map until it finds the requested element
-// or reaches a dead end.
+// or reaches a dead end.  Variable expansion is supported when the value
+// is a string with ${} wrapped around a key.
 func (s *MapSource) Get(_ context.Context, path ...string) (interface{}, bool) {
 	return s.getRecursive(nil, 0, path...)
 }
 
-// Get traverses a configuration map until it finds the requested element
-// or reaches a dead end.
 func (s *MapSource) getRecursive(valueAtTopOfRecursionStack interface{}, recursionDepth int, path ...string) (interface{}, bool) {
 	if recursionDepth > infiniteRecursionDepthLimit {
 		return nil, false
@@ -269,7 +268,8 @@ func (s *PrefixSource) Get(ctx context.Context, path ...string) (interface{}, bo
 // value or will return false for found.
 type MultiSource []Source
 
-// Get a value from the ordered set of Sources.
+// Get a value from the ordered set of Sources.  Variable expansion is supported when the value
+// is a string with ${} wrapped around a key.
 func (ms MultiSource) Get(ctx context.Context, path ...string) (interface{}, bool) {
 	return ms.getRecursive(ctx, nil, 0, path...)
 }

--- a/source.go
+++ b/source.go
@@ -79,12 +79,12 @@ func NewMapSource(m map[string]interface{}) *MapSource {
 // Get traverses a configuration map until it finds the requested element
 // or reaches a dead end.
 func (s *MapSource) Get(_ context.Context, path ...string) (interface{}, bool) {
-	return s.getRecursive(nil, nil, 0, path...)
+	return s.getRecursive(nil, 0, path...)
 }
 
 // Get traverses a configuration map until it finds the requested element
 // or reaches a dead end.
-func (s *MapSource) getRecursive(_ context.Context, valueAtTopOfRecursionStack interface{}, recursionDepth int, path ...string) (interface{}, bool) {
+func (s *MapSource) getRecursive(valueAtTopOfRecursionStack interface{}, recursionDepth int, path ...string) (interface{}, bool) {
 	if recursionDepth > infiniteRecursionDepthLimit {
 		return nil, false
 	}
@@ -112,7 +112,7 @@ func (s *MapSource) getRecursive(_ context.Context, valueAtTopOfRecursionStack i
 			valueAtTopOfRecursionStack = vString
 		}
 		key := unwrap([]byte(vString))
-		subValue, subFound := s.getRecursive(nil, valueAtTopOfRecursionStack, recursionDepth+1, strings.Split(string(key), "_")...)
+		subValue, subFound := s.getRecursive(valueAtTopOfRecursionStack, recursionDepth+1, strings.Split(string(key), "_")...)
 		if !subFound {
 			return valueAtTopOfRecursionStack, true
 		}

--- a/source.go
+++ b/source.go
@@ -311,7 +311,6 @@ func (ms MultiSource) getRecursive(ctx context.Context, valueAtTopOfRecursionSta
 
 func unwrap(source []byte) []byte {
 	return envPattern.ReplaceAllFunc(source, func(match []byte) []byte {
-		name := match[2 : len(match)-1] // strip ${}
-		return []byte(string(name))
+		return match[2 : len(match)-1] // strip ${}
 	})
 }

--- a/source_test.go
+++ b/source_test.go
@@ -436,6 +436,18 @@ func TestMultiSourceVariableExpansion(t *testing.T) {
 	}
 }
 
+func TestMultiSourceVariableExpansionNotFound(t *testing.T) {
+	s := MultiSource{
+		NewMapSource(map[string]interface{}{
+			"b": "${a}",
+		}),
+	}
+	_, found := s.Get(context.Background(), "b")
+	if found {
+		t.Error("should not have found b with multi source and no key mapping substitution")
+	}
+}
+
 func TestMultiSourceVariableExpansionInverted(t *testing.T) {
 	s := MultiSource{
 		NewMapSource(map[string]interface{}{
@@ -451,6 +463,22 @@ func TestMultiSourceVariableExpansionInverted(t *testing.T) {
 	}
 	if s, ok := v.(string); !ok || s != "aa" {
 		t.Error("b does not equal aa")
+	}
+}
+
+func TestMultiSourceVariableExpansionRecursionDepthLimit(t *testing.T) {
+	// rather than erroring out when we detect possible infinite
+	// recursion, indicate that no "final" value could be found
+	s := MultiSource{
+		NewMapSource(map[string]interface{}{
+			"a": "${b}",
+			"b": "${c}",
+			"c": "${a}",
+		}),
+	}
+	_, found := s.Get(context.Background(), "a")
+	if found {
+		t.Error("should not have found a with multi source and no key mapping substitution")
 	}
 }
 


### PR DESCRIPTION
The README already implied that the feature this PR introduces was a thing.  It was not, but after this PR, it is!  Consider this PR a proposal for a feature, and because I did not add feature-specific function names to the SDK, this PR represents a _breaking_ change and will require a major version update.  That said, I expect that no one will _actually_ be broken upon updating.

**Below was my original review request and is now outdated.**

All backward compatibility remains intact, so this will be a minor version update.

I have a specific review question.  This PR, as it is, behaves such that if a substitution is desired, but implemented incorrectly, the result is to return `nil, false` (nil value, not found) rather than the unsubstituted value.

For example, imagine the env vars are:
```
A=aValue
```
and the YAML file is:
```
B: "${C}"
```

The SDK could behave such that "find `B`" returns `nil, false` or it returns `"${C}", true`.  I think I prefer the former, as it's the earliest warning sign to the user of this lib that they're seeking a key (`C`) that does not exist.
